### PR TITLE
Bypass columns that cannot or will not respond to

### DIFF
--- a/lib/indexter/validator.rb
+++ b/lib/indexter/validator.rb
@@ -70,7 +70,7 @@ module Indexter
       # These are the columns we have indexes on that also end in COL_SUFFIX
       def indexes(table)
         ActiveRecord::Base.connection.indexes(table).map do |idx_def|
-          idx_def.columns.select { |col| col.end_with? *@suffixes }
+          idx_def.columns.select { |col| col.end_with? *@suffixes } if idx_def.columns.respond_to?(:select)
         end.flatten
       end
 


### PR DESCRIPTION
Fixes #6

```
lewis@Lewis-MacBook-Pro lotus % bundle exec rake indexter:validate
{:suffixes=>["_id", "_uuid"], :exclusions=>{"schema_migrations"=>[]}, :missing=>{"invitations"=>["invitations_batch_id"], "invitations_batches"=>["organisation_id"], "skills"=>["parent_id"], "external_model_mappings"=>["lotus_model_id", "external_id"]}}
```